### PR TITLE
update optional unwrapping of 'value'

### DIFF
--- a/Magic/AppDelegate.swift
+++ b/Magic/AppDelegate.swift
@@ -21,7 +21,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 //    then the user would have to click the menubar item twice
 //    to make Desktop reappear
 
-    var desktopShown: Bool {
+    var isDesktopHidden: Bool {
         var finderPlistPath: URL?
 
         if #available(OSX 10.12, *) {
@@ -41,22 +41,23 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                 print("Plist Convertion Error: \(error)")
             }
 
-            if let value = dict?.value(forKey: "CreateDesktop") as? String {
-                return Bool(value)!
+            if let value = dict?.value(forKey: "CreateDesktop") as? String,
+                let result = Bool(value) {
+                return result
             }
         } else {
             // Fallback on earlier versions
-            if let dict = NSDictionary(contentsOf: finderPlistPath!) {
-                return Bool(dict.value(forKey: "CreateDesktop") as! String)!
-                //                  dict.value(forKey: "CreateDesktop") would produce
-                //                  Any?, Bool initializer only accepts (Bool), (String), (NSNumber)
-                //
-                //                  dict.value(forKey: "CreateDesktop") as? Bool
-                //                  does not work either, somehow the system would try to convert
-                //                  dict.value(forKey: "CreateDesktop") NSTaggedPointerString
-                //                  to NSNumber first, which fails.
+            if let dict = NSDictionary(contentsOf: finderPlistPath!),
+                let value = dict.value(forKey: "CreateDesktop") as? String,
+                let result = Bool(value) {
+                return result
             }
-
+            //    dict.value(forKey: "CreateDesktop") would produce
+            //    Any?, Bool initializer only accepts (Bool), (String), (NSNumber)
+            //    dict.value(forKey: "CreateDesktop") as? Bool
+            //    does not work either, somehow the system would try to convert
+            //    dict.value(forKey: "CreateDesktop") NSTaggedPointerString
+            //    to NSNumber first, which fails.
         }
         
         return false
@@ -87,7 +88,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
         let process = Process()
         process.launchPath = "/bin/bash"
-        process.arguments = ["-c", "defaults write com.apple.finder CreateDesktop \(!desktopShown); killall Finder"]
+        process.arguments = ["-c", "defaults write com.apple.finder CreateDesktop \(!isDesktopHidden); killall Finder"]
         process.launch()
         print("Desktop State Flipped")
     }

--- a/Magic/Base.lproj/MainMenu.xib
+++ b/Magic/Base.lproj/MainMenu.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="13156.6" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="13156.6"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14490.70"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -629,7 +629,7 @@
                             <menuItem title="Show Sidebar" keyEquivalent="s" id="kIP-vf-haE">
                                 <modifierMask key="keyEquivalentModifierMask" control="YES" command="YES"/>
                                 <connections>
-                                    <action selector="toggleSourceList:" target="-1" id="iwa-gc-5KM"/>
+                                    <action selector="toggleSidebar:" target="-1" id="iwa-gc-5KM"/>
                                 </connections>
                             </menuItem>
                             <menuItem title="Enter Full Screen" keyEquivalent="f" id="4J7-dP-txa">
@@ -684,7 +684,7 @@
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="335" y="390" width="480" height="360"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="2048" height="1129"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1920" height="1080"/>
             <view key="contentView" wantsLayer="YES" id="EiT-Mj-1SZ">
                 <rect key="frame" x="0.0" y="0.0" width="480" height="360"/>
                 <autoresizingMask key="autoresizingMask"/>


### PR DESCRIPTION
to guard against cases where the value of CreateDesktop stored in Finder plist is not convertible to Boolean
